### PR TITLE
Fixed issue where the scope of the containment for the draggable item…

### DIFF
--- a/js/adapt-ppq.js
+++ b/js/adapt-ppq.js
@@ -123,12 +123,14 @@ define(function(require) {
         },
 
         onQuestionRendered:function() {
-            this.$('.ppq-pinboard-container-inner').imageready(_.bind(function() {
+            var $pinboardContainerInner = this.$('.ppq-pinboard-container-inner');
+
+            $pinboardContainerInner.imageready(_.bind(function() {
                 for (var i=0, l=this._pinViews.length; i<l; i++) {
                     var pin = this._pinViews[i];
                     
                     pin.dragObj = new Draggabilly(pin.el, {
-                        containment:'.ppq-pinboard-container-inner'
+                        containment: $pinboardContainerInner
                     });
 
                     if (!this.model.get('_isEnabled')) pin.dragObj.disable();


### PR DESCRIPTION
…s wasn't tied to the component view. If more than one PPQ was rendered on the page, the pins would be lost on the subsequent components once a user attempted to drag a pin.